### PR TITLE
Modify query for only one-month terms

### DIFF
--- a/features/subscription/spark_job.py
+++ b/features/subscription/spark_job.py
@@ -35,7 +35,10 @@ def run(spark, args):
 
     all_subs.createOrReplaceTempView("sub_table")
 
-    sub_sql = get_sub_sql(query_dt, churn_check_date.strftime('%Y-%m-%d'))
+    sub_sql = get_sub_sql(
+        query_dt=query_dt,
+        max_expiration_dt=next_month_date.strftime('%Y-%m-%d'),
+        after_expiration_dt=churn_check_date.strftime('%Y-%m-%d'))
     subs = spark.sql(sub_sql)
 
     subs.write.parquet(args['output_path'], mode='overwrite')


### PR DESCRIPTION
Filter out subs expiring more than a month later.

There shouldn't be 7-day free-trialists in there because of the `current_subscription_state = 2` clause, not sure whether that actually occurs or not.

Again, will change to the more accurate sub table when it's ready.

To run tests
1. Create a virtual environment and/or activate it
2. You'll need Java and Spark if you don't already have it locally, and add JAVAHOME and SPARK_HOME to your bash profile pointing to the correct executable, and modify your PYTHONPATH (e.g. `export PYTHONPATH=$SPARK_HOME/python/:$PYTHONPATH`)
3. Install the requirements in the virtual env f you haven't already `pip install -r requirements.txt`
4. From the top-level directory: `python -m pytest tests/`