### PR TITLE
No overlong sessions

### DIFF
--- a/features/session/query.py
+++ b/features/session/query.py
@@ -27,15 +27,28 @@ activity_sql = """
 select
     user_id,
     -- 1 day is counted for a session bridging 2 days
-    count(distinct cast(session_start as date)) active_days,
+    count(distinct session_start_date) active_days,
     count(distinct session_id) num_sessions,
-    avg(unix_timestamp(session_end) - unix_timestamp(session_start)) / 60.0 avg_session_length,
-    cast(approx_percentile(unix_timestamp(session_end) - unix_timestamp(session_start), 0.5) as float) / 60.0 median_session_length,
-    sum(unix_timestamp(session_end) - unix_timestamp(session_start)) / 60.0 total_timespent
+    avg(session_length_min) avg_session_length,
+    percentile_approx(session_length_min, 0.5) median_session_length,
+    sum(session_length_min) total_timespent
 from
-    sessions
+(
+    select
+        user_id,
+        session_id,
+        cast(session_start as date) session_start_date,
+        cast(unix_timestamp(session_end) - unix_timestamp(session_start) as float) / 60.0 as session_length_min
+    from
+        sessions
+
+) session_lengths
+where
+    -- remove sessions 8 hours or longer
+    session_length < 480
 group by
     user_id
+
 """
 
 device_sql = """

--- a/features/session/query.py
+++ b/features/session/query.py
@@ -45,7 +45,7 @@ from
 ) session_lengths
 where
     -- remove sessions 8 hours or longer
-    session_length < 480
+    session_length_min < 480
 group by
     user_id
 


### PR DESCRIPTION
Removing sessions longer than 8 hours which are assumed to be an app running w/o session reset (<9% of sessions).