### PR TITLE
Device code not device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *.csv
 *.parquet
 *.crc
-
+*_SUCCESS
 
 *.pyc
 

--- a/features/session/query.py
+++ b/features/session/query.py
@@ -6,7 +6,11 @@ def get_session_sql(query_dt='', days_back=28):
     select
         user_id,
         session_id,
-        device,
+        case
+            when device_code = 'taco' then 'appletv'
+            when device_code = 'appletv' then 'appletv_classic'
+            else device_code
+        end as device_code,
         min(cast(event_timestamp as timestamp)) session_start,
         max(cast(event_timestamp as timestamp)) session_end
     from
@@ -18,7 +22,11 @@ def get_session_sql(query_dt='', days_back=28):
     group by
         user_id,
         session_id,
-        device
+        case
+            when device_code = 'taco' then 'appletv'
+            when device_code = 'appletv' then 'appletv_classic'
+            else device_code
+        end
     """.format(dt_start=utils.dt_start(query_dt, days_back),
                query_dt=query_dt)
 
@@ -54,11 +62,11 @@ group by
 device_sql = """
 select
     user_id,
-    device,
+    device_code,
     sum(unix_timestamp(session_end) - unix_timestamp(session_start)) / 60.0 device_minutes
 from
     sessions
 group by
     user_id,
-    device
+    device_code
 """

--- a/features/session/query.py
+++ b/features/session/query.py
@@ -27,15 +27,28 @@ activity_sql = """
 select
     user_id,
     -- 1 day is counted for a session bridging 2 days
-    count(distinct cast(session_start as date)) active_days,
+    count(distinct session_start_date) active_days,
     count(distinct session_id) num_sessions,
-    avg(unix_timestamp(session_end) - unix_timestamp(session_start)) / 60.0 avg_session_length,
-    cast(approx_percentile(unix_timestamp(session_end) - unix_timestamp(session_start), 0.5) as float) / 60.0 median_session_length,
-    sum(unix_timestamp(session_end) - unix_timestamp(session_start)) / 60.0 total_timespent
+    avg(session_length_min) avg_session_length,
+    percentile_approx(session_length_min, 0.5) median_session_length,
+    sum(session_length_min) total_timespent
 from
-    sessions
+(
+    select
+        user_id,
+        session_id,
+        cast(session_start as date) session_start_date,
+        cast(unix_timestamp(session_end) - unix_timestamp(session_start) as float) / 60.0 as session_length_min
+    from
+        sessions
+
+) session_lengths
+where
+    -- remove sessions 8 hours or longer
+    session_length < 480
 group by
     user_id
+
 """
 
 device_sql = """

--- a/features/session/query.py
+++ b/features/session/query.py
@@ -6,11 +6,7 @@ def get_session_sql(query_dt='', days_back=28):
     select
         user_id,
         session_id,
-        case
-            when device_code = 'taco' then 'appletv'
-            when device_code = 'appletv' then 'appletv_classic'
-            else device_code
-        end as device_code,
+        case when device_code = 'taco' then 'appletv' else device_code end as device_code,
         min(cast(event_timestamp as timestamp)) session_start,
         max(cast(event_timestamp as timestamp)) session_end
     from
@@ -22,11 +18,7 @@ def get_session_sql(query_dt='', days_back=28):
     group by
         user_id,
         session_id,
-        case
-            when device_code = 'taco' then 'appletv'
-            when device_code = 'appletv' then 'appletv_classic'
-            else device_code
-        end
+        case when device_code = 'taco' then 'appletv' else device_code end
     """.format(dt_start=utils.dt_start(query_dt, days_back),
                query_dt=query_dt)
 

--- a/features/session/query.py
+++ b/features/session/query.py
@@ -45,7 +45,7 @@ from
 ) session_lengths
 where
     -- remove sessions 8 hours or longer
-    session_length < 480
+    session_length_min < 480
 group by
     user_id
 

--- a/features/session/spark_job.py
+++ b/features/session/spark_job.py
@@ -15,14 +15,10 @@ def parse(row):
         'dt': row.dt,
         'user_id': properties.get('userId', None),
         'session_id': properties.get('sessionId', None),
-        'device': properties.get('device', None),
+        'device_code': properties.get('device_code', None),
         'event_timestamp': properties.get('eventTimestamp', None)
     }
     return Row(**record)
-
-
-def rename(col_name):
-    return col_name.lower().replace(' ', '_').replace(')', '')
 
 
 def run(spark, args):
@@ -46,9 +42,6 @@ def run(spark, args):
 
     user_device_timespent = spark.sql(query.device_sql)
     user_device_timespent_pivoted = user_device_timespent.groupby('user_id') \
-        .pivot('device').agg(sum('device_minutes'))
+        .pivot('device_code').agg(sum('device_minutes'))
     user_device_timespent_pivoted.cache()
-    for col in user_device_timespent_pivoted.columns:
-        user_device_timespent_pivoted = user_device_timespent_pivoted.withColumnRenamed(
-            col, rename(col))
     user_device_timespent_pivoted.write.parquet(args['output_path_device'], mode='overwrite')

--- a/tests/session_helper.py
+++ b/tests/session_helper.py
@@ -3,7 +3,7 @@ dt_1_records = [
         'properties': {
             'userId': 1,
             'sessionId': 'a1',
-            'device': 'ANDROID',
+            'device_code': 'android',
             'eventTimestamp': '2018-12-04T20:00:00.000Z'
         }
     },
@@ -11,7 +11,7 @@ dt_1_records = [
         'properties': {
             'userId': 1,
             'sessionId': 'a1',
-            'device': 'ANDROID',
+            'device_code': 'android',
             'eventTimestamp': '2018-12-04T21:00:00.000Z'
         }
     },
@@ -19,7 +19,7 @@ dt_1_records = [
         'properties': {
             'userId': 1,
             'sessionId': 'a1',
-            'device': 'ANDROID',
+            'device_code': 'android',
             'eventTimestamp': '2018-12-0323:59:00.000Z'
         }
     },
@@ -27,7 +27,7 @@ dt_1_records = [
         'properties': {
             'userId': 1,
             'sessionId': 'a5',
-            'device': 'ANDROID',
+            'device_code': 'android',
             'eventTimestamp': '2018-12-04T09:00:00.000Z'
         }
     },
@@ -35,7 +35,7 @@ dt_1_records = [
         'properties': {
             'userId': 1,
             'sessionId': 'a5',
-            'device': 'ANDROID',
+            'device_code': 'android',
             'eventTimestamp': '2018-12-04T10:00:00.000Z'
         }
     },
@@ -44,7 +44,7 @@ dt_1_records = [
 
             'userId': 2,
             'sessionId': 'b1',
-            'device': 'Apple TV',
+            'device_code': 'appletv',
             'eventTimestamp': '2018-12-04T09:00:00.000Z'
         }
     },
@@ -53,7 +53,7 @@ dt_1_records = [
 
             'userId': 2,
             'sessionId': 'b1',
-            'device': 'Apple TV',
+            'device_code': 'appletv',
             'eventTimestamp': '2018-12-04T09:05:00.000Z'
         }
     },
@@ -62,7 +62,7 @@ dt_1_records = [
 
             'userId': 2,
             'sessionId': 'b1',
-            'device': 'Apple TV',
+            'device_code': 'appletv',
             'eventTimestamp': '2018-12-04T10:00:00.000Z'
         }
     }
@@ -73,7 +73,7 @@ dt_2_records = [
         'properties': {
             'userId': 1,
             'sessionId': 'a2',
-            'device': 'Desktop',
+            'device_code': 'desktop',
             'eventTimestamp': '2018-12-15T20:00:00.000Z'
         }
     },
@@ -81,7 +81,7 @@ dt_2_records = [
         'properties': {
             'userId': 1,
             'sessionId': 'a2',
-            'device': 'Desktop',
+            'device_code': 'desktop',
             'eventTimestamp': '2018-12-15T22:00:00.000Z'
         }
     }
@@ -92,7 +92,7 @@ dt_3_records = [
         'properties': {
             'userId': 1,
             'sessionId': 'a4',
-            'device': 'Amazon Fire TV',
+            'device_code': 'firetv',
             'eventTimestamp': '2019-01-01T05:00:00.000Z'
         }
     },
@@ -100,7 +100,7 @@ dt_3_records = [
         'properties': {
             'userId': 1,
             'sessionId': 'a3',
-            'device': 'Amazon Fire TV',
+            'device_code': 'firetv',
             'eventTimestamp': '2018-12-31T21:00:00.000Z'
         }
     },
@@ -108,7 +108,7 @@ dt_3_records = [
         'properties': {
             'userId': 1,
             'sessionId': 'a3',
-            'device': 'Amazon Fire TV',
+            'device_code': 'firetv',
             'eventTimestamp': '2018-12-31T23:00:00.000Z'
         }
     },
@@ -116,7 +116,7 @@ dt_3_records = [
         'properties': {
             'userId': 2,
             'sessionId': 'b3',
-            'device': 'Apple TV',
+            'device_code': 'appletv',
             'eventTimestamp': '2018-12-31T09:00:00.000Z'
         }
     },
@@ -124,7 +124,7 @@ dt_3_records = [
         'properties': {
             'userId': 2,
             'sessionId': 'b3',
-            'device': 'Apple TV',
+            'device_code': 'appletv',
             'eventTimestamp': '2018-12-31T09:05:00.000Z'
         }
     },
@@ -132,7 +132,7 @@ dt_3_records = [
         'properties': {
             'userId': 2,
             'sessionId': 'b3',
-            'device': 'Apple TV',
+            'device_code': 'appletv',
             'eventTimestamp': '2018-12-31T10:00:00.000Z'
         }
     },
@@ -140,7 +140,7 @@ dt_3_records = [
         'properties': {
             'userId': 2,
             'sessionId': 'b4',
-            'device': 'Apple TV',
+            'device_code': 'appletv',
             'eventTimestamp': '2019-01-01T10:00:00.000Z'
         }
     }

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -23,7 +23,7 @@ def test_parse():
 
 
 def test_parse_missing_dt():
-    test_dict = "{'some': 'values'}"
+    test_dict = {'some': 'values'}
     test_data = Row(value=json.dumps(test_dict))
     with raises(AttributeError):
         row = spark_job.parse(test_data)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -7,28 +7,23 @@ from tests import session_helper
 from tests.utils import get_data_dict
 
 
-def test_rename():
-    """Rename device 'categories' to lowercase w/ no spaces."""
-    assert spark_job.rename('Cool Smart TV 5000)') == 'cool_smart_tv_5000'
-
-
 def test_parse():
     test_dict = {
         'properties': {
             'userId': 1,
             'sessionId': 'a1',
-            'device': 'ANDROID',
+            'device_code': 'android',
             'eventTimestamp': '2018-12-04T20:00:00.000Z'
         }
     }
     test_data = Row(value=json.dumps(test_dict), dt='2018-04-21')
     row = spark_job.parse(test_data)
-    for col in ['user_id', 'session_id', 'device', 'event_timestamp']:
+    for col in ['user_id', 'session_id', 'device_code', 'event_timestamp']:
         assert col in row
 
 
 def test_parse_missing_dt():
-    test_dict = {'some': 'values'}
+    test_dict = "{'some': 'values'}"
     test_data = Row(value=json.dumps(test_dict))
     with raises(AttributeError):
         row = spark_job.parse(test_data)
@@ -46,7 +41,7 @@ def test_parse_different_schema():
     }
     test_data = Row(value=json.dumps(test_dict), dt='2018-04-21')
     row = spark_job.parse(test_data)
-    for col in ['user_id', 'session_id', 'device', 'event_timestamp']:
+    for col in ['user_id', 'session_id', 'device_code', 'event_timestamp']:
         assert row[col] is None
 
 
@@ -79,7 +74,7 @@ def validate_device(spark, output_path):
     assert data.count() == 2
     data_dict = get_data_dict(data)
     assert float(data_dict[1]['android']) == 120.0
-    assert float(data_dict[2]['apple_tv']) == 120.0
+    assert float(data_dict[2]['appletv']) == 120.0
     assert data_dict[2]['desktop'] is None
 
 


### PR DESCRIPTION
Goal was to clean up the `device` column for device timespent. DP already has cleanup through its `device_code` column, however so using that instead.
- However will change uninformative device_code `'taco'` to `'appletv'`. (I found taco = appletv, appletv = apple tv classic.)
- Because `device_code` is already lowercase with no spaces, the `rename` function isn't needed.
