### PR TITLE
Decouple session jobs

### DIFF
--- a/features/activity/__init__.py
+++ b/features/activity/__init__.py
@@ -1,0 +1,1 @@
+from . import spark_job

--- a/features/activity/query.py
+++ b/features/activity/query.py
@@ -1,0 +1,27 @@
+activity_sql = """
+select
+    user_id,
+    -- 1 day is counted for a session bridging 2 days
+    count(distinct session_start_date) active_days,
+    count(distinct session_id) num_sessions,
+    avg(session_length_min) avg_session_length,
+    percentile_approx(session_length_min, 0.5) median_session_length,
+    sum(session_length_min) total_timespent
+from
+(
+    select
+        user_id,
+        session_id,
+        cast(session_start as date) session_start_date,
+        cast(unix_timestamp(session_end) - unix_timestamp(session_start) as float) / 60.0 as session_length_min
+    from
+        sessions
+
+) session_lengths
+where
+    -- remove sessions 8 hours or longer
+    session_length_min < 480
+group by
+    user_id
+
+"""

--- a/features/activity/spark_job.py
+++ b/features/activity/spark_job.py
@@ -1,0 +1,15 @@
+from features import utils
+from . import query
+
+
+def run(spark, args):
+    query_dt = args['dt']
+    dt_start = utils.dt_start(query_dt, days_back=28)
+    sessions = spark.read.load(args['input_path']).where(
+        "dt between '{dt_start}' and '{query_dt}'".format(
+            query_dt=query_dt, dt_start=dt_start))
+    sessions.createOrReplaceTempView('sessions')
+
+    user_activity = spark.sql(query.activity_sql)
+    user_activity.write.parquet(
+        utils.dt_path(args['output_path'], query_dt), mode='overwrite')

--- a/features/device/__init__.py
+++ b/features/device/__init__.py
@@ -1,0 +1,1 @@
+from . import spark_job

--- a/features/device/query.py
+++ b/features/device/query.py
@@ -1,0 +1,22 @@
+device_sql = """
+select
+    user_id,
+    device_code,
+    sum(session_length_min) device_minutes
+from
+(
+    select
+        user_id,
+        device_code,
+        session_id,
+        cast(unix_timestamp(session_end) - unix_timestamp(session_start) as float) / 60.0 as session_length_min
+    from
+        sessions
+
+) session_lengths
+where
+    session_length_min < 480
+group by
+    user_id,
+    device_code
+"""

--- a/features/device/spark_job.py
+++ b/features/device/spark_job.py
@@ -1,0 +1,23 @@
+from pyspark.sql.functions import sum
+from features import utils
+from . import query
+
+
+def run(spark, args):
+    query_dt = args['dt']
+    dt_start = utils.dt_start(query_dt, days_back=28)
+    # Job dependent on 28 days of successful session job runs
+    sessions = spark.read.load(args['input_path']).where(
+        "dt between '{dt_start}' and '{query_dt}'".format(
+            query_dt=query_dt, dt_start=dt_start))
+
+    sessions = spark.read.load(args['input_path'])
+    sessions.createOrReplaceTempView('sessions')
+
+    user_device_timespent = spark.sql(query.device_sql)
+    user_device_timespent_pivoted = user_device_timespent.groupby('user_id') \
+        .pivot('device_code').agg(sum('device_minutes'))
+    user_device_timespent_pivoted.cache()
+
+    user_device_timespent_pivoted.write.parquet(
+        utils.dt_path(args['output_path'], query_dt), mode='overwrite')

--- a/features/session/__init__.py
+++ b/features/session/__init__.py
@@ -1,0 +1,1 @@
+from . import spark_job

--- a/features/session/spark_job.py
+++ b/features/session/spark_job.py
@@ -1,6 +1,5 @@
 import json
 from pyspark.sql import Row
-from pyspark.sql.functions import sum
 
 from features import utils
 from . import query
@@ -9,7 +8,6 @@ from . import query
 def parse(row):
     value = json.loads(row.value)
     properties = value.get('properties', {})
-
     # explicitly parse and rename for optimization
     record = {
         'dt': row.dt,
@@ -24,24 +22,15 @@ def parse(row):
 def run(spark, args):
 
     query_dt = args['dt']
-    dt_start = utils.dt_start(query_dt, days_back=28)
+    dt_start = utils.dt_start(query_dt, days_back=1)
 
     # off-the-bat 'where' for optimization
     segment = spark.read.load(args['input_path']).where(
-        "dt between '{dt_start}' and '{query_dt}'".format(
+        "dt in ('{dt_start}', '{query_dt}')".format(
             dt_start=dt_start, query_dt=query_dt))
 
-    events = spark.createDataFrame(segment.rdd.map(parse))
+    events = spark.createDataFrame(segment.rdd.map(parse), samplingRatio=.4)
     events.createOrReplaceTempView('events')
-    # reusable sessions dataframe
     sessions = spark.sql(query.get_session_sql(query_dt))
-    sessions.createOrReplaceTempView('sessions')
-
-    user_activity = spark.sql(query.activity_sql)
-    user_activity.write.parquet(args['output_path_activity'], mode='overwrite')
-
-    user_device_timespent = spark.sql(query.device_sql)
-    user_device_timespent_pivoted = user_device_timespent.groupby('user_id') \
-        .pivot('device_code').agg(sum('device_minutes'))
-    user_device_timespent_pivoted.cache()
-    user_device_timespent_pivoted.write.parquet(args['output_path_device'], mode='overwrite')
+    # Other jobs will use daily session roll-up
+    sessions.write.parquet(utils.dt_path(args['output_path'], query_dt), mode='overwrite')

--- a/glue/activity.py
+++ b/glue/activity.py
@@ -5,7 +5,7 @@ from pyspark.context import SparkContext
 from awsglue.context import GlueContext
 from awsglue.job import Job
 
-from features.session import spark_job
+from features.activity import spark_job
 
 args = getResolvedOptions(sys.argv, ['JOB_NAME', 'dt', 'input_path', 'output_path'])
 sc = SparkContext()

--- a/glue/device.py
+++ b/glue/device.py
@@ -5,7 +5,7 @@ from pyspark.context import SparkContext
 from awsglue.context import GlueContext
 from awsglue.job import Job
 
-from features.session import spark_job
+from features.device import spark_job
 
 args = getResolvedOptions(sys.argv, ['JOB_NAME', 'dt', 'input_path', 'output_path'])
 sc = SparkContext()

--- a/tests/session_helper.py
+++ b/tests/session_helper.py
@@ -15,6 +15,7 @@ dt_1_records = [
             'eventTimestamp': '2018-12-04T21:00:00.000Z'
         }
     },
+    # sessions in wrong dt partition don't count
     {
         'properties': {
             'userId': 1,
@@ -136,10 +137,27 @@ dt_3_records = [
             'eventTimestamp': '2018-12-31T10:00:00.000Z'
         }
     },
+    # overlong session will be in sessions but not dependent queries
     {
         'properties': {
             'userId': 2,
             'sessionId': 'b4',
+            'device_code': 'appletv',
+            'eventTimestamp': '2018-12-31T12:00:00.000Z'
+        }
+    },
+    {
+        'properties': {
+            'userId': 2,
+            'sessionId': 'b4',
+            'device_code': 'appletv',
+            'eventTimestamp': '2018-12-31T21:00:00.000Z'
+        }
+    },
+    {
+        'properties': {
+            'userId': 2,
+            'sessionId': 'b5',
             'device_code': 'appletv',
             'eventTimestamp': '2019-01-01T10:00:00.000Z'
         }

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,8 +1,12 @@
 import json
+import pandas as pd
 from pyspark.sql import Row
 from pytest import raises
 
-from features.session import spark_job
+import features.session as session
+import features.activity as activity
+import features.device as device
+
 from tests import session_helper
 from tests.utils import get_data_dict
 
@@ -17,7 +21,7 @@ def test_parse():
         }
     }
     test_data = Row(value=json.dumps(test_dict), dt='2018-04-21')
-    row = spark_job.parse(test_data)
+    row = session.spark_job.parse(test_data)
     for col in ['user_id', 'session_id', 'device_code', 'event_timestamp']:
         assert col in row
 
@@ -26,7 +30,7 @@ def test_parse_missing_dt():
     test_dict = {'some': 'values'}
     test_data = Row(value=json.dumps(test_dict))
     with raises(AttributeError):
-        row = spark_job.parse(test_data)
+        session.spark_job.parse(test_data)
         assert 'dt' in AttributeError
 
 
@@ -40,24 +44,31 @@ def test_parse_different_schema():
         }
     }
     test_data = Row(value=json.dumps(test_dict), dt='2018-04-21')
-    row = spark_job.parse(test_data)
+    row = session.spark_job.parse(test_data)
     for col in ['user_id', 'session_id', 'device_code', 'event_timestamp']:
         assert row[col] is None
 
 
-def setup_sample(spark, records=None, dt='', input_path=''):
+def setup_sample(spark, args, records=None):
     """Build a Spark DataFrame out of records from seession_helper and write to parquet."""
     rows = [Row(value=json.dumps(record)) for record in records]
     data = spark.createDataFrame(rows)
 
+    dt = args['dt']
     [yr, mo, day] = dt.split('-')
     sample_input_path = '{input_path}/yr={yr}/mo={mo}/dt={dt}/'.format(
-        input_path=input_path, yr=yr, mo=mo, dt=dt)
+        input_path=args['input_path'], yr=yr, mo=mo, dt=dt)
     data.write.parquet(sample_input_path, mode='overwrite')
 
 
-def validate_activity(spark, output_path):
-    data = spark.read.load(output_path)
+def validate_session(spark, args):
+    data = spark.read.load(args['output_path']).where("dt = '{}'".format(args['dt']))
+    assert data.count() == 3
+    assert 'a4' not in list(data['session_id'])
+
+
+def validate_activity(spark, args):
+    data = spark.read.load(args['output_path'])
     assert data.count() == 2
     data_dict = get_data_dict(data)
     assert data_dict[1]['active_days'] == 3
@@ -69,27 +80,49 @@ def validate_activity(spark, output_path):
     assert float(data_dict[1]['total_timespent']) == 360.0
 
 
-def validate_device(spark, output_path):
-    data = spark.read.load(output_path)
+def validate_device(spark, args):
+    data = spark.read.load(args['output_path'])
     assert data.count() == 2
     data_dict = get_data_dict(data)
     assert float(data_dict[1]['android']) == 120.0
     assert float(data_dict[2]['appletv']) == 120.0
-    assert data_dict[2]['desktop'] is None
+    assert pd.isnull(data_dict[2]['desktop'])
 
 
 def test_job(spark):
+    """Test daily session job AND dependent jobs."""
     input_path = 'tests/sample_input/session/'
-    setup_sample(spark, records=session_helper.dt_1_records, dt='2018-12-05', input_path=input_path)
-    setup_sample(spark, records=session_helper.dt_2_records, dt='2018-12-15', input_path=input_path)
-    setup_sample(spark, records=session_helper.dt_3_records, dt='2018-12-31', input_path=input_path)
+    session_output_path = 'tests/sample_output/session/'
 
+    # mock spark job on THREE days
+    [dt_1, dt_2, dt_3] = ['2018-12-05', '2018-12-16', '2019-01-01']
+    test_args = {
+        'dt': dt_1,
+        'input_path': input_path,
+        'output_path': session_output_path
+    }
+    setup_sample(spark, test_args, records=session_helper.dt_1_records)
+    session.spark_job.run(spark, test_args)
+
+    test_args['dt'] = dt_2
+    setup_sample(spark, test_args, records=session_helper.dt_2_records)
+    session.spark_job.run(spark, test_args)
+
+    test_args['dt'] = dt_3
+    setup_sample(spark, test_args, records=session_helper.dt_3_records)
+    session.spark_job.run(spark, test_args)
+
+    validate_session(spark, test_args)
+
+    # dependent jobs - from dt, looking back 28 days
     test_args = {
         'dt': '2019-01-01',
-        'input_path': input_path,
-        'output_path_activity': 'tests/sample_output/activity/',
-        'output_path_device': 'tests/sample_output/device/'
+        'input_path': session_output_path,
+        'output_path': 'tests/sample_output/activity/',
     }
-    spark_job.run(spark, test_args)
-    validate_activity(spark, test_args['output_path_activity'])
-    validate_device(spark, test_args['output_path_device'])
+    activity.spark_job.run(spark, test_args)
+    validate_activity(spark, test_args)
+
+    test_args['output_path'] = 'tests/sample_output/device/'
+    device.spark_job.run(spark, test_args)
+    validate_device(spark, test_args)


### PR DESCRIPTION
Instead of having one massive job that 1. Gets sessions 2. Calculates activity metrics 3. Calculates devices over 28 days, these are split up:
- sessions gets 1 day of sessions
- activity calculates activity metrics over 28 days of sessions
- device calculates device metrics over 28 days of sessions

This will make the DAG more complicated but it's less risky.

The tests still are in a single test because tests should not depend on each other.