### PR TITLE
Jobs default to yesterday's dt partition

### DIFF
--- a/features/utils.py
+++ b/features/utils.py
@@ -11,3 +11,7 @@ def dt_start(dt, days_back=28):
 
 def dt_path(output_path, query_dt):
     return os.path.join(output_path, 'dt={}'.format(query_dt))
+
+
+def yesterday_dt():
+    return (datetime.now() - timedelta(1)).strftime('%Y-%m-%d')

--- a/glue/activity.py
+++ b/glue/activity.py
@@ -6,8 +6,11 @@ from awsglue.context import GlueContext
 from awsglue.job import Job
 
 from features.activity import spark_job
+from features.utils import yesterday_dt
 
 args = getResolvedOptions(sys.argv, ['JOB_NAME', 'dt', 'input_path', 'output_path'])
+if 'dt' not in args:
+    args['dt'] = yesterday_dt()
 sc = SparkContext()
 glueContext = GlueContext(sc)
 spark = glueContext.spark_session

--- a/glue/device.py
+++ b/glue/device.py
@@ -6,8 +6,11 @@ from awsglue.context import GlueContext
 from awsglue.job import Job
 
 from features.device import spark_job
+from features.utils import yesterday_dt
 
 args = getResolvedOptions(sys.argv, ['JOB_NAME', 'dt', 'input_path', 'output_path'])
+if args['dt'] == 'yesterday':
+    args['dt'] = yesterday_dt()
 sc = SparkContext()
 glueContext = GlueContext(sc)
 spark = glueContext.spark_session

--- a/glue/join.py
+++ b/glue/join.py
@@ -6,6 +6,7 @@ from awsglue.context import GlueContext
 from awsglue.job import Job
 
 from features.join import spark_job
+from features.utils import yesterday_dt
 
 args = getResolvedOptions(sys.argv, [
     'JOB_NAME',
@@ -14,6 +15,9 @@ args = getResolvedOptions(sys.argv, [
     'input_performance',
     'input_activity',
     'output_path'])
+if args['dt'] == 'yesterday':
+    args['dt'] = yesterday_dt()
+
 sc = SparkContext()
 glueContext = GlueContext(sc)
 spark = glueContext.spark_session

--- a/glue/performance.py
+++ b/glue/performance.py
@@ -6,8 +6,11 @@ from awsglue.context import GlueContext
 from awsglue.job import Job
 
 from features.performance import spark_job
+from features.utils import yesterday_dt
 
 args = getResolvedOptions(sys.argv, ['JOB_NAME', 'dt', 'input_path', 'output_path'])
+if args['dt'] == 'yesterday':
+    args['dt'] = yesterday_dt()
 sc = SparkContext()
 glueContext = GlueContext(sc)
 spark = glueContext.spark_session

--- a/glue/session.py
+++ b/glue/session.py
@@ -6,8 +6,12 @@ from awsglue.context import GlueContext
 from awsglue.job import Job
 
 from features.session import spark_job
+from features.utils import yesterday_dt
 
 args = getResolvedOptions(sys.argv, ['JOB_NAME', 'dt', 'input_path', 'output_path'])
+if args['dt'] == 'yesterday':
+    args['dt'] = yesterday_dt()
+
 sc = SparkContext()
 glueContext = GlueContext(sc)
 spark = glueContext.spark_session

--- a/glue/subscription.py
+++ b/glue/subscription.py
@@ -6,8 +6,12 @@ from awsglue.context import GlueContext
 from awsglue.job import Job
 
 from features.subscription import spark_job
+from features.utils import yesterday_dt
 
 args = getResolvedOptions(sys.argv, ['JOB_NAME', 'dt', 'input_path', 'output_path'])
+if args['dt'] == 'yesterday':
+    args['dt'] = yesterday_dt()
+
 sc = SparkContext()
 glueContext = GlueContext(sc)
 spark = glueContext.spark_session

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 from features import utils
 
 
@@ -13,3 +14,7 @@ def test_dt_start():
 
 def test_dt_path():
     assert utils.dt_path('s3://mypath', '2019-01-09') == 's3://mypath/dt=2019-01-09'
+
+
+def test_yesterday_dt():
+    assert utils.yesterday_dt() == (datetime.now() - timedelta(1)).strftime('%Y-%m-%d')


### PR DESCRIPTION
Readying for a tactical deploy:
- Jobs will use yesterday's dt if `dt` arg is 'yesterday'.
- I made `yesterday` the default arg for the existing jobs
- There is no test of `yesterday_dt` because the test would be rewriting the function