### PR TITLE
Fix device code

### DIFF
--- a/features/device/query.py
+++ b/features/device/query.py
@@ -12,6 +12,8 @@ from
         cast(unix_timestamp(session_end) - unix_timestamp(session_start) as float) / 60.0 as session_length_min
     from
         sessions
+    where
+        device_code is not null
 
 ) session_lengths
 where

--- a/features/device/spark_job.py
+++ b/features/device/spark_job.py
@@ -11,7 +11,6 @@ def run(spark, args):
         "dt between '{dt_start}' and '{query_dt}'".format(
             query_dt=query_dt, dt_start=dt_start))
 
-    sessions = spark.read.load(args['input_path'])
     sessions.createOrReplaceTempView('sessions')
 
     user_device_timespent = spark.sql(query.device_sql)

--- a/features/session/query.py
+++ b/features/session/query.py
@@ -15,6 +15,7 @@ def get_session_sql(query_dt='', days_back=1):
         dt between '{dt_start}' and '{query_dt}'
         and substr(event_timestamp, 1, 10) >= '{dt_start}'
         and substr(event_timestamp, 1, 10) < '{query_dt}'
+        and device_code is not null
     group by
         user_id,
         session_id,

--- a/features/session/spark_job.py
+++ b/features/session/spark_job.py
@@ -13,7 +13,7 @@ def parse(row):
         'dt': row.dt,
         'user_id': properties.get('userId', None),
         'session_id': properties.get('sessionId', None),
-        'device_code': properties.get('device_code', None),
+        'device_code': properties.get('deviceCode', None),
         'event_timestamp': properties.get('eventTimestamp', None)
     }
     return Row(**record)

--- a/tests/session_helper.py
+++ b/tests/session_helper.py
@@ -3,7 +3,7 @@ dt_1_records = [
         'properties': {
             'userId': 1,
             'sessionId': 'a1',
-            'device_code': 'android',
+            'deviceCode': 'android',
             'eventTimestamp': '2018-12-04T20:00:00.000Z'
         }
     },
@@ -11,7 +11,7 @@ dt_1_records = [
         'properties': {
             'userId': 1,
             'sessionId': 'a1',
-            'device_code': 'android',
+            'deviceCode': 'android',
             'eventTimestamp': '2018-12-04T21:00:00.000Z'
         }
     },
@@ -20,7 +20,7 @@ dt_1_records = [
         'properties': {
             'userId': 1,
             'sessionId': 'a1',
-            'device_code': 'android',
+            'deviceCode': 'android',
             'eventTimestamp': '2018-12-0323:59:00.000Z'
         }
     },
@@ -28,7 +28,7 @@ dt_1_records = [
         'properties': {
             'userId': 1,
             'sessionId': 'a5',
-            'device_code': 'android',
+            'deviceCode': 'android',
             'eventTimestamp': '2018-12-04T09:00:00.000Z'
         }
     },
@@ -36,7 +36,7 @@ dt_1_records = [
         'properties': {
             'userId': 1,
             'sessionId': 'a5',
-            'device_code': 'android',
+            'deviceCode': 'android',
             'eventTimestamp': '2018-12-04T10:00:00.000Z'
         }
     },
@@ -45,7 +45,7 @@ dt_1_records = [
 
             'userId': 2,
             'sessionId': 'b1',
-            'device_code': 'appletv',
+            'deviceCode': 'appletv',
             'eventTimestamp': '2018-12-04T09:00:00.000Z'
         }
     },
@@ -54,7 +54,7 @@ dt_1_records = [
 
             'userId': 2,
             'sessionId': 'b1',
-            'device_code': 'appletv',
+            'deviceCode': 'appletv',
             'eventTimestamp': '2018-12-04T09:05:00.000Z'
         }
     },
@@ -63,7 +63,7 @@ dt_1_records = [
 
             'userId': 2,
             'sessionId': 'b1',
-            'device_code': 'appletv',
+            'deviceCode': 'appletv',
             'eventTimestamp': '2018-12-04T10:00:00.000Z'
         }
     }
@@ -74,7 +74,7 @@ dt_2_records = [
         'properties': {
             'userId': 1,
             'sessionId': 'a2',
-            'device_code': 'desktop',
+            'deviceCode': 'desktop',
             'eventTimestamp': '2018-12-15T20:00:00.000Z'
         }
     },
@@ -82,7 +82,7 @@ dt_2_records = [
         'properties': {
             'userId': 1,
             'sessionId': 'a2',
-            'device_code': 'desktop',
+            'deviceCode': 'desktop',
             'eventTimestamp': '2018-12-15T22:00:00.000Z'
         }
     }
@@ -93,7 +93,7 @@ dt_3_records = [
         'properties': {
             'userId': 1,
             'sessionId': 'a4',
-            'device_code': 'firetv',
+            'deviceCode': 'firetv',
             'eventTimestamp': '2019-01-01T05:00:00.000Z'
         }
     },
@@ -101,7 +101,7 @@ dt_3_records = [
         'properties': {
             'userId': 1,
             'sessionId': 'a3',
-            'device_code': 'firetv',
+            'deviceCode': 'firetv',
             'eventTimestamp': '2018-12-31T21:00:00.000Z'
         }
     },
@@ -109,7 +109,7 @@ dt_3_records = [
         'properties': {
             'userId': 1,
             'sessionId': 'a3',
-            'device_code': 'firetv',
+            'deviceCode': 'firetv',
             'eventTimestamp': '2018-12-31T23:00:00.000Z'
         }
     },
@@ -117,7 +117,7 @@ dt_3_records = [
         'properties': {
             'userId': 2,
             'sessionId': 'b3',
-            'device_code': 'appletv',
+            'deviceCode': 'appletv',
             'eventTimestamp': '2018-12-31T09:00:00.000Z'
         }
     },
@@ -125,7 +125,7 @@ dt_3_records = [
         'properties': {
             'userId': 2,
             'sessionId': 'b3',
-            'device_code': 'appletv',
+            'deviceCode': 'appletv',
             'eventTimestamp': '2018-12-31T09:05:00.000Z'
         }
     },
@@ -133,7 +133,7 @@ dt_3_records = [
         'properties': {
             'userId': 2,
             'sessionId': 'b3',
-            'device_code': 'appletv',
+            'deviceCode': 'appletv',
             'eventTimestamp': '2018-12-31T10:00:00.000Z'
         }
     },
@@ -142,7 +142,7 @@ dt_3_records = [
         'properties': {
             'userId': 2,
             'sessionId': 'b4',
-            'device_code': 'appletv',
+            'deviceCode': 'appletv',
             'eventTimestamp': '2018-12-31T12:00:00.000Z'
         }
     },
@@ -150,7 +150,7 @@ dt_3_records = [
         'properties': {
             'userId': 2,
             'sessionId': 'b4',
-            'device_code': 'appletv',
+            'deviceCode': 'appletv',
             'eventTimestamp': '2018-12-31T21:00:00.000Z'
         }
     },
@@ -158,7 +158,7 @@ dt_3_records = [
         'properties': {
             'userId': 2,
             'sessionId': 'b5',
-            'device_code': 'appletv',
+            'deviceCode': 'appletv',
             'eventTimestamp': '2019-01-01T10:00:00.000Z'
         }
     }


### PR DESCRIPTION
Noticed a bug in the parsing - Telegraph is all camel case in raw form.

I also now filtered out events with null `deviceCode`s. These are from events device:deactivate, video:playbackmarker, stethoscope:ping, subscription:check. Don't believe these events would be first or last event so not critical for my session roll-ups.

Lesson learned: Check the physical output of these Spark jobs as bugs might still make it past the unit tests and review.